### PR TITLE
getPresignedUrl

### DIFF
--- a/.changeset/smooth-moles-sell.md
+++ b/.changeset/smooth-moles-sell.md
@@ -1,0 +1,5 @@
+---
+'@effect-use/gcp-gcs': minor
+---
+
+add getPresignedUrl method

--- a/packages/gcp-gcs/src/index.ts
+++ b/packages/gcp-gcs/src/index.ts
@@ -15,6 +15,12 @@ type GCSWriteError = {
   stack: unknown
 }
 
+type GCSUrlSigningError = {
+  _tag: 'GCSUrlSigningError'
+  meassage: string
+  stack: unknown
+}
+
 /**
  * Writes data to key in bucket
  * @param bucket
@@ -31,6 +37,30 @@ export const write = (
       try: () => gcs.bucket(bucket).file(key).save(data),
       catch: (e) => ({
         _tag: 'GCSWriteError',
+        message: `${e}`,
+        error: (e as Error).stack,
+      }),
+    })
+  )
+
+export const getPresignedUrl = (
+  bucket: string,
+  key: string,
+  lifetime: number // time to live in milliseconds (relative to when URL is created)
+) =>
+  Effect.flatMap(GCS, (gcs) =>
+    Effect.tryPromise({
+      try: () =>
+        gcs
+          .bucket(bucket)
+          .file(key)
+          .getSignedUrl({
+            version: 'v4',
+            action: 'read',
+            expires: Date.now() + lifetime,
+          }),
+      catch: (e) => ({
+        _tag: 'GCSUrlSigningError',
         message: `${e}`,
         error: (e as Error).stack,
       }),


### PR DESCRIPTION
adds method for use with GCS layer for generating pre-signed URLs for downloading GCS objects for a given lifetime